### PR TITLE
Notify confidence by voice and text with Mission Planner

### DIFF
--- a/scripts/t265_to_mavlink.py
+++ b/scripts/t265_to_mavlink.py
@@ -59,10 +59,9 @@ compass_enabled = 0
 #           H_aeroRef_T265Ref = np.array([[0,0,-1,0],[1,0,0,0],[0,-1,0,0],[0,0,0,1]])
 #           H_T265body_aeroBody = np.linalg.inv(H_aeroRef_T265Ref)
 #     Forward, USB port to the left: 
-# Downfacing (you need to tilt the vehicle's nose up a little (not flat) when launch the T265 realsense-ros node, otherwise the initial yaw will be randomized, read here: https://github.com/IntelRealSense/librealsense/issues/4080
-# Tilt the vehicle to any other sides and the yaw might not be as stable):
+# Downfacing (you need to tilt the vehicle's nose up a little - not flat - before you run the script, otherwise the initial yaw will be randomized, read here for more details: https://github.com/IntelRealSense/librealsense/issues/4080. Tilt the vehicle to any other sides and the yaw might not be as stable):
 #     Downfacing, USB port to the right : 
-#           H_aeroRef_T265Ref = np.array([[0,1, 0,0],[1,0,0,0],[0,0,-1,0],[0,0,0,1]]), 
+#           H_aeroRef_T265Ref = np.array([[0,1, 0,0],[1,0,0,0],[0,0,-1,0],[0,0,0,1]])
 #           H_T265body_aeroBody = np.linalg.inv(np.array([[0,0,-1,0],[1,0,0,0],[0,-1,0,0],[0,0,0,1]]))
 #     Downfacing, USB port to the left  : 
 #     Downfacing, USB port to the back  :         

--- a/scripts/t265_to_mavlink.py
+++ b/scripts/t265_to_mavlink.py
@@ -177,7 +177,7 @@ def send_confidence_level_dummy_message():
     global data, current_confidence
     if data is not None:
         # Show confidence level on terminal
-        print("INFO: Tracker confidence: ", pose_data_confidence_level[data.tracker_confidence])
+        print("INFO: Tracking confidence: ", pose_data_confidence_level[data.tracker_confidence])
 
         # Send MAVLink message to show confidence level numerically
         msg = vehicle.message_factory.vision_position_delta_encode(


### PR DESCRIPTION
This function is to be used with Mission Planner GCS. 

Added voice announcement as well as text notification on HUD. Both will pop up when the system starts sending vision message and only when confidence level changes (from med to high for example).